### PR TITLE
fpu: Added C_DIV type

### DIFF
--- a/rtl/riscv_ex_stage.sv
+++ b/rtl/riscv_ex_stage.sv
@@ -535,7 +535,7 @@ module riscv_ex_stage
            assign {fpu_vec_op, fpu_op_mod, fpu_op} = apu_op_i;
            assign {fpu_int_fmt, fpu_src_fmt, fpu_dst_fmt, fp_rnd_mode} = apu_flags_i;
 
-           localparam C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
+           localparam fpnew_pkg::unit_type_t C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
 
            logic FPU_ready_int;
 


### PR DESCRIPTION
Added C_DIV typing, as Vivado raises type errors